### PR TITLE
Método de obtener contactos agregado

### DIFF
--- a/src/ApiContactos.Tests/ContactosTest.cs
+++ b/src/ApiContactos.Tests/ContactosTest.cs
@@ -1,0 +1,39 @@
+using System.Net;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+public class ContactosTest : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public ContactosTest(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task ObtenerContactos_ReturnsExpectedContactList()
+    {
+        // Arrange
+        var client = _factory.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/obtenercontactos");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var responseString = await response.Content.ReadAsStringAsync();
+        var contactos = JsonSerializer.Deserialize<List<string>>(responseString, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        Assert.NotNull(contactos);
+        Assert.Equal(3, contactos.Count);
+        Assert.Contains("Amin Espinoza", contactos);
+        Assert.Contains("Oscar Barajas", contactos);
+        Assert.Contains("Pepe Rodelo", contactos);
+    }
+}

--- a/src/ContactosAPI/Program.cs
+++ b/src/ContactosAPI/Program.cs
@@ -59,6 +59,16 @@ app.MapGet("/weatherforecast", () =>
 .WithName("GetWeatherForecast")
 .WithOpenApi();
 
+app.MapGet("/obtenercontactos", () =>
+{
+    var contactos = new List<string> { "Amin Espinoza", "Oscar Barajas", "Pepe Rodelo" };
+    return contactos;
+})
+.WithName("ObtenerContactos")
+.WithOpenApi();
+
+app.Run();
+
 app.Run();
 
 record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)


### PR DESCRIPTION
This pull request introduces a new feature to the `ContactosAPI` project by adding an endpoint to retrieve a list of contacts and a corresponding test to validate its functionality. The most important changes include the addition of the `/obtenercontactos` endpoint and a new test class to ensure the endpoint behaves as expected.

### New Feature: `/obtenercontactos` Endpoint

* [`src/ContactosAPI/Program.cs`](diffhunk://#diff-edad546dd6640508130d8d610679b38c7cd900b3c963968a07ea1f66e67b9393R62-R71): Added a new GET endpoint `/obtenercontactos` that returns a hardcoded list of contact names. This endpoint is named "ObtenerContactos" and is configured with OpenAPI support.

### Testing: Contactos API

* [`src/ApiContactos.Tests/ContactosTest.cs`](diffhunk://#diff-cf8ee411fd8abbbfd8cf4668d1737a9953cdd5e56bb0a6e2a7a31d03567bbcb8R1-R39): Introduced a new test class `ContactosTest` using `Xunit` and `WebApplicationFactory` to test the `/obtenercontactos` endpoint. The test verifies that the endpoint returns a 200 OK status and the expected list of contact names.

#3 